### PR TITLE
Prometheus Metrics for Teeracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,13 +2270,13 @@ dependencies = [
  "itp-enclave-metrics",
  "itp-ocall-api",
  "itp-test",
+ "itp-types",
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "serde 1.0.136",
  "serde_json 1.0.79",
  "sgx_tstd",
- "substrate-fixed",
  "thiserror 1.0.30",
  "thiserror 1.0.9",
  "url 2.1.1",
@@ -2583,10 +2583,10 @@ dependencies = [
 name = "itp-enclave-metrics"
 version = "0.8.0"
 dependencies = [
+ "itp-types",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "substrate-fixed",
 ]
 
 [[package]]
@@ -2824,6 +2824,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "substrate-api-client",
+ "substrate-fixed",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,9 @@ name = "ita-exchange-oracle"
 version = "0.8.0"
 dependencies = [
  "itc-rest-client",
+ "itp-enclave-metrics",
+ "itp-ocall-api",
+ "itp-test",
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
@@ -2583,6 +2586,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
+ "substrate-fixed",
 ]
 
 [[package]]

--- a/app-libs/exchange-oracle/Cargo.toml
+++ b/app-libs/exchange-oracle/Cargo.toml
@@ -10,6 +10,7 @@ std = [
     "itc-rest-client/std",
     "itp-enclave-metrics/std",
     "itp-ocall-api/std",
+    "itp-types/std",
     "log/std",
     "serde/std",
     "serde_json/std",
@@ -19,6 +20,7 @@ std = [
 sgx = [
     "itc-rest-client/sgx",
     "itp-enclave-metrics/sgx",
+    "itp-types/sgx",
     "sgx_tstd",
     "thiserror_sgx",
     "url_sgx",
@@ -41,12 +43,12 @@ lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-substrate-fixed = { package = "substrate-fixed", git = "https://github.com/encointer/substrate-fixed",tag = "v0.5.9"}
 
 # internal dependencies
 itc-rest-client = { path = "../../core/rest-client", default-features = false }
 itp-enclave-metrics = { path = "../../core-primitives/enclave-metrics", default-features = false }
 itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
+itp-types = { path = "../../core-primitives/types", default-features = false }
 
 [dev-dependencies]
 itp-test = { path = "../../core-primitives/test" }

--- a/app-libs/exchange-oracle/Cargo.toml
+++ b/app-libs/exchange-oracle/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 default = ["std"]
 std = [
     "itc-rest-client/std",
+    "itp-enclave-metrics/std",
+    "itp-ocall-api/std",
     "log/std",
     "serde/std",
     "serde_json/std",
@@ -16,6 +18,7 @@ std = [
 ]
 sgx = [
     "itc-rest-client/sgx",
+    "itp-enclave-metrics/sgx",
     "sgx_tstd",
     "thiserror_sgx",
     "url_sgx",
@@ -42,4 +45,8 @@ substrate-fixed = { package = "substrate-fixed", git = "https://github.com/encoi
 
 # internal dependencies
 itc-rest-client = { path = "../../core/rest-client", default-features = false }
+itp-enclave-metrics = { path = "../../core-primitives/enclave-metrics", default-features = false }
+itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
 
+[dev-dependencies]
+itp-test = { path = "../../core-primitives/test" }

--- a/app-libs/exchange-oracle/src/coingecko.rs
+++ b/app-libs/exchange-oracle/src/coingecko.rs
@@ -23,13 +23,16 @@ use crate::{
 	ExchangeRate, GetExchangeRate,
 };
 use itc_rest_client::{http_client::HttpClient, rest_client::RestClient, RestGet, RestPath};
+use itp_enclave_metrics::{EnclaveMetric, ExchangeRateOracleMetric};
+use itp_ocall_api::EnclaveMetricsOCallApi;
 use lazy_static::lazy_static;
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::{
 	collections::HashMap,
 	string::{String, ToString},
-	time::Duration,
+	sync::Arc,
+	time::{Duration, Instant},
 	vec::Vec,
 };
 use url::Url;
@@ -50,21 +53,37 @@ lazy_static! {
 	]);
 }
 /// REST client to make requests to CoinGecko.
-pub struct CoinGeckoClient {
+pub struct CoinGeckoClient<OCallApi> {
 	client: RestClient<HttpClient>,
+	ocall_api: Arc<OCallApi>,
 }
-impl CoinGeckoClient {
-	pub fn new(baseurl: Url) -> Self {
+
+impl<OCallApi> CoinGeckoClient<OCallApi>
+where
+	OCallApi: EnclaveMetricsOCallApi,
+{
+	pub fn new(baseurl: Url, ocall_api: Arc<OCallApi>) -> Self {
 		let http_client = HttpClient::new(true, Some(COINGECKO_TIMEOUT), None, None);
 		let rest_client = RestClient::new(http_client, baseurl);
-		CoinGeckoClient { client: rest_client }
+		CoinGeckoClient { client: rest_client, ocall_api }
 	}
+
 	pub fn base_url() -> Result<Url, Error> {
 		Url::parse(COINGECKO_URL).map_err(|e| Error::Other(format!("{:?}", e).into()))
 	}
+
+	fn update_metric(&self, metric: ExchangeRateOracleMetric) {
+		if let Err(e) = self.ocall_api.update_metric(EnclaveMetric::ExchangeRateOracle(metric)) {
+			error!("Failed to update enclave metric, sgx_status_t: {}", e)
+		}
+	}
+
+	fn metric_source() -> String {
+		"coingecko".to_string()
+	}
 }
 
-impl TradingPairId for CoinGeckoClient {
+impl<OCallApi> TradingPairId for CoinGeckoClient<OCallApi> {
 	fn crypto_currency_id(&mut self, trading_pair: TradingPair) -> Result<String, Error> {
 		let key = trading_pair.crypto_currency;
 		match SYMBOL_ID_MAP.get(&key as &str) {
@@ -92,10 +111,20 @@ impl RestPath<String> for CoinGeckoMarket {
 	}
 }
 
-impl GetExchangeRate for CoinGeckoClient {
+impl<OCallApi> GetExchangeRate for CoinGeckoClient<OCallApi>
+where
+	OCallApi: EnclaveMetricsOCallApi,
+{
 	fn get_exchange_rate(&mut self, trading_pair: TradingPair) -> Result<ExchangeRate, Error> {
+		self.update_metric(
+			ExchangeRateOracleMetric::NumberRequestsIncrement(Self::metric_source()),
+		);
+
 		let fiat_id = self.fiat_currency_id(trading_pair.clone())?;
 		let crypto_id = self.crypto_currency_id(trading_pair.clone())?;
+
+		let timer_start = Instant::now();
+
 		let response = self
 			.client
 			.get_with::<String, CoinGeckoMarket>(
@@ -103,13 +132,28 @@ impl GetExchangeRate for CoinGeckoClient {
 				&[(COINGECKO_PARAM_CURRENCY, &fiat_id), (COINGECKO_PARAM_COIN, &crypto_id)],
 			)
 			.map_err(Error::RestClient)?;
+
+		self.update_metric(ExchangeRateOracleMetric::ResponseTime(
+			Self::metric_source(),
+			timer_start.elapsed().as_millis(),
+		));
+
 		let list = response.0;
 		if list.is_empty() {
 			error!("Got no market data from coinGecko. Check params {:?} ", trading_pair);
 			return Err(Error::NoValidData)
 		}
+
 		match list[0].current_price {
-			Some(r) => Ok(ExchangeRate::from_num(r)),
+			Some(r) => {
+				let exchange_rate = ExchangeRate::from_num(r);
+				self.update_metric(ExchangeRateOracleMetric::ExchangeRate(
+					Self::metric_source(),
+					trading_pair.key(),
+					exchange_rate,
+				));
+				Ok(exchange_rate)
+			},
 			None => {
 				error!("Failed to get the exchange rate {}", TradingPair::key(trading_pair));
 				Err(Error::EmptyExchangeRate)
@@ -121,11 +165,13 @@ impl GetExchangeRate for CoinGeckoClient {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use codec::Decode;
 	use core::assert_matches::assert_matches;
+	use itp_test::mock::metrics_ocall_mock::MetricsOCallMock;
+	type TestCoinGeckoClient = CoinGeckoClient<MetricsOCallMock>;
 
 	fn get_coingecko_crypto_currency_id(crypto_currency: &str) -> Result<String, Error> {
-		let url = CoinGeckoClient::base_url().unwrap();
-		let mut coingecko_client = CoinGeckoClient::new(url);
+		let mut coingecko_client = create_coingecko_client();
 		let trading_pair = TradingPair {
 			crypto_currency: crypto_currency.to_string(),
 			fiat_currency: "USD".to_string(),
@@ -165,8 +211,7 @@ mod tests {
 
 	#[test]
 	fn get_exchange_rate_for_undefined_coingecko_crypto_currency_fails() {
-		let url = CoinGeckoClient::base_url().unwrap();
-		let mut coingecko_client = CoinGeckoClient::new(url);
+		let mut coingecko_client = create_coingecko_client();
 		let trading_pair = TradingPair {
 			crypto_currency: "invalid_coin".to_string(),
 			fiat_currency: "USD".to_string(),
@@ -177,8 +222,7 @@ mod tests {
 
 	#[test]
 	fn get_exchange_rate_for_undefined_fiat_currency_fails() {
-		let url = CoinGeckoClient::base_url().unwrap();
-		let mut coingecko_client = CoinGeckoClient::new(url);
+		let mut coingecko_client = create_coingecko_client();
 		let trading_pair =
 			TradingPair { crypto_currency: "DOT".to_string(), fiat_currency: "CH".to_string() };
 		let result = coingecko_client.get_exchange_rate(trading_pair);
@@ -186,9 +230,34 @@ mod tests {
 	}
 
 	#[test]
+	fn get_exchange_rate_updates_metrics() {
+		let url = TestCoinGeckoClient::base_url().unwrap();
+		let metrics_ocall_api = Arc::new(MetricsOCallMock::default());
+		let mut coingecko_client = CoinGeckoClient::new(url, metrics_ocall_api.clone());
+
+		let trading_pair =
+			TradingPair { crypto_currency: "BTC".to_string(), fiat_currency: "USD".to_string() };
+		let _bit_usd = coingecko_client.get_exchange_rate(trading_pair.clone()).unwrap();
+
+		let metrics_updates = metrics_ocall_api.get_metrics_updates();
+		assert_eq!(3, metrics_updates.len());
+		let exchange_rate_metric: EnclaveMetric =
+			Decode::decode(&mut metrics_updates.get(2).unwrap().clone().as_slice()).unwrap();
+
+		let _trading_pair_key = trading_pair.key();
+		assert_matches!(
+			exchange_rate_metric,
+			EnclaveMetric::ExchangeRateOracle(ExchangeRateOracleMetric::ExchangeRate(
+				_,
+				_trading_pair_key,
+				_bit_usd
+			))
+		);
+	}
+
+	#[test]
 	fn get_exchange_rate_from_coingecko_works() {
-		let url = CoinGeckoClient::base_url().unwrap();
-		let mut coingecko_client = CoinGeckoClient::new(url);
+		let mut coingecko_client = create_coingecko_client();
 		let dot_usd = coingecko_client
 			.get_exchange_rate(TradingPair {
 				crypto_currency: "DOT".to_string(),
@@ -219,5 +288,10 @@ mod tests {
 		assert!(dot_usd > zero);
 		//Ensure that the exchange rates' values make sense
 		assert_eq!((dot_usd / bit_usd).round(), (dot_chf / bit_chf).round());
+	}
+
+	fn create_coingecko_client() -> TestCoinGeckoClient {
+		let url = TestCoinGeckoClient::base_url().unwrap();
+		CoinGeckoClient::new(url, Arc::new(MetricsOCallMock::default()))
 	}
 }

--- a/app-libs/exchange-oracle/src/coingecko.rs
+++ b/app-libs/exchange-oracle/src/coingecko.rs
@@ -20,11 +20,12 @@ use crate::sgx_reexport_prelude::*;
 use crate::{
 	error::Error,
 	types::{TradingPair, TradingPairId},
-	ExchangeRate, GetExchangeRate,
+	GetExchangeRate,
 };
 use itc_rest_client::{http_client::HttpClient, rest_client::RestClient, RestGet, RestPath};
 use itp_enclave_metrics::{EnclaveMetric, ExchangeRateOracleMetric};
 use itp_ocall_api::EnclaveMetricsOCallApi;
+use itp_types::ExchangeRate;
 use lazy_static::lazy_static;
 use log::*;
 use serde::{Deserialize, Serialize};

--- a/app-libs/exchange-oracle/src/error.rs
+++ b/app-libs/exchange-oracle/src/error.rs
@@ -23,12 +23,12 @@ use std::boxed::Box;
 pub enum Error {
 	#[error("Rest client error")]
 	RestClient(itc_rest_client::error::Error),
-	#[error("Other error")]
-	Other(Box<dyn std::error::Error>),
 	#[error("Could not retrieve any data")]
 	NoValidData,
 	#[error("Value for exchange rate is null")]
 	EmptyExchangeRate,
 	#[error("Invalid id for crypto currency")]
 	InvalidCryptoCurrencyId,
+	#[error("Other error")]
+	Other(Box<dyn std::error::Error>),
 }

--- a/app-libs/exchange-oracle/src/lib.rs
+++ b/app-libs/exchange-oracle/src/lib.rs
@@ -33,13 +33,11 @@ pub mod sgx_reexport_prelude {
 }
 
 use crate::{error::Error, types::TradingPair};
-use substrate_fixed::types::U32F32;
+use itp_types::ExchangeRate;
 
 pub mod coingecko;
 pub mod error;
 pub mod types;
-
-pub type ExchangeRate = U32F32;
 
 pub trait GetExchangeRate {
 	/// Get the cryptocurrency/fiat_currency exchange rate

--- a/core-primitives/enclave-metrics/Cargo.toml
+++ b/core-primitives/enclave-metrics/Cargo.toml
@@ -13,13 +13,17 @@ sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-substrate-fixed = { package = "substrate-fixed", git = "https://github.com/encointer/substrate-fixed",tag = "v0.5.9"}
+
+# internal
+itp-types = { path = "../types", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+    "itp-types/std",
     "codec/std",
 ]
 sgx = [
+    "itp-types/sgx",
     "sgx_tstd",
 ]

--- a/core-primitives/enclave-metrics/Cargo.toml
+++ b/core-primitives/enclave-metrics/Cargo.toml
@@ -13,6 +13,7 @@ sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+substrate-fixed = { package = "substrate-fixed", git = "https://github.com/encointer/substrate-fixed",tag = "v0.5.9"}
 
 [features]
 default = ["std"]

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -24,11 +24,24 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
+use std::string::String;
+use substrate_fixed::types::U32F32;
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, Debug)]
 pub enum EnclaveMetric {
 	SetSidechainBlockHeight(u64),
 	TopPoolSizeSet(u64),
 	TopPoolSizeIncrement,
 	TopPoolSizeDecrement,
+	ExchangeRateOracle(ExchangeRateOracleMetric),
+}
+
+#[derive(Encode, Decode, Debug)]
+pub enum ExchangeRateOracleMetric {
+	/// Exchange Rate from CoinGecko - (Source, TradingPair, ExchangeRate)
+	ExchangeRate(String, String, U32F32),
+	/// Response time of the request in [ms]. (Source, ResponseTime)
+	ResponseTime(String, u128),
+	/// Increment the number of requests (Source)
+	NumberRequestsIncrement(String),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -24,8 +24,8 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
+use itp_types::ExchangeRate;
 use std::string::String;
-use substrate_fixed::types::U32F32;
 
 #[derive(Encode, Decode, Debug)]
 pub enum EnclaveMetric {
@@ -39,7 +39,7 @@ pub enum EnclaveMetric {
 #[derive(Encode, Decode, Debug)]
 pub enum ExchangeRateOracleMetric {
 	/// Exchange Rate from CoinGecko - (Source, TradingPair, ExchangeRate)
-	ExchangeRate(String, String, U32F32),
+	ExchangeRate(String, String, ExchangeRate),
 	/// Response time of the request in [ms]. (Source, ResponseTime)
 	ResponseTime(String, u128),
 	/// Increment the number of requests (Source)

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -11,6 +11,7 @@ chrono          = { version = "0.4.19", default-features = false, features = ["a
 serde           = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json      = { version = "1.0", default-features = false, features = ["alloc"] }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master", default-features = false }
+substrate-fixed = { package = "substrate-fixed", git = "https://github.com/encointer/substrate-fixed", tag = "v0.5.9"}
 
 sgx_tstd = { branch = "master", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true}
 

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -1,17 +1,19 @@
 #![cfg_attr(all(not(target_env = "sgx"), not(feature = "std")), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 
-use codec::{Decode, Encode};
 #[cfg(feature = "sgx")]
 use sgx_tstd as std;
+
+use codec::{Decode, Encode};
+use itp_storage::storage_entry::StorageEntry;
 use sp_runtime::{
 	generic::{Block as BlockG, Header as HeaderG, SignedBlock as SignedBlockG},
 	traits::BlakeTwo256,
 	OpaqueExtrinsic,
 };
 use std::vec::Vec;
+use substrate_fixed::types::U32F32;
 
-use itp_storage::storage_entry::StorageEntry;
 pub use rpc::*;
 pub mod rpc;
 
@@ -41,6 +43,9 @@ pub type MrEnclave = [u8; 32];
 pub type ConfirmCallFn = ([u8; 2], ShardIdentifier, H256, Vec<u8>);
 pub type ShieldFundsFn = ([u8; 2], Vec<u8>, Amount, ShardIdentifier);
 pub type CallWorkerFn = ([u8; 2], Request);
+
+/// Teeracle types
+pub type ExchangeRate = U32F32;
 
 pub type Enclave = EnclaveGen<AccountId>;
 /// Simple blob to hold an encoded call

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1143,6 +1143,8 @@ name = "ita-exchange-oracle"
 version = "0.8.0"
 dependencies = [
  "itc-rest-client",
+ "itp-enclave-metrics",
+ "itp-ocall-api",
  "lazy_static",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
@@ -1366,6 +1368,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
+ "substrate-fixed",
 ]
 
 [[package]]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1145,13 +1145,13 @@ dependencies = [
  "itc-rest-client",
  "itp-enclave-metrics",
  "itp-ocall-api",
+ "itp-types",
  "lazy_static",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "serde 1.0.136",
  "serde_json 1.0.78",
  "sgx_tstd",
- "substrate-fixed",
  "thiserror 1.0.9",
  "url",
 ]
@@ -1365,10 +1365,10 @@ dependencies = [
 name = "itp-enclave-metrics"
 version = "0.8.0"
 dependencies = [
+ "itp-types",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "substrate-fixed",
 ]
 
 [[package]]
@@ -1581,6 +1581,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "substrate-api-client",
+ "substrate-fixed",
 ]
 
 [[package]]

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -683,19 +683,21 @@ fn update_market_data_internal(
 	crypto_currency: String,
 	fiat_currency: String,
 ) -> Result<Vec<OpaqueExtrinsic>> {
+	type ExchangeRateClient = CoinGeckoClient<OcallApi>;
+
 	let signer = Ed25519Seal::unseal()?;
 
 	let extrinsics_factory =
 		ExtrinsicsFactory::new(genesis_hash, signer, GLOBAL_NONCE_CACHE.clone());
 
 	// Get the exchange rate
-	let url = match CoinGeckoClient::base_url() {
+	let url = match ExchangeRateClient::base_url() {
 		Ok(u) => u,
 		Err(e) => return Err(Error::Other(e.into())),
 	};
 
 	let trading_pair = TradingPair { crypto_currency, fiat_currency };
-	let mut coingecko_client = CoinGeckoClient::new(url.clone());
+	let mut coingecko_client = ExchangeRateClient::new(url.clone(), Arc::new(OcallApi));
 	let rate = match coingecko_client.get_exchange_rate(trading_pair.clone()) {
 		Ok(r) => r,
 		Err(e) => {

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -83,7 +83,7 @@ pub fn produce_sidechain_block_and_import_it() {
 		AuthorTopFilter {},
 		state_handler.clone(),
 		shielding_key,
-		Arc::new(MetricsOCallMock {}),
+		Arc::new(MetricsOCallMock::default()),
 	));
 	let top_pool_operation_handler =
 		Arc::new(TestTopPoolExecutor::new(rpc_author.clone(), stf_executor.clone()));

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -600,7 +600,7 @@ pub fn test_setup() -> (
 			AllowAllTopsFilter,
 			state_handler.clone(),
 			encryption_key.clone(),
-			Arc::new(MetricsOCallMock {}),
+			Arc::new(MetricsOCallMock::default()),
 		)),
 		state,
 		shard,

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -20,6 +20,7 @@
 use crate::{
 	account_funding::EnclaveAccountInfo,
 	error::{Error, ServiceResult},
+	teeracle_metrics::update_teeracle_metrics,
 };
 use async_trait::async_trait;
 use itp_enclave_metrics::EnclaveMetric;
@@ -157,6 +158,7 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 			EnclaveMetric::TopPoolSizeDecrement => {
 				ENCLAVE_SIDECHAIN_TOP_POOL_SIZE.dec();
 			},
+			EnclaveMetric::ExchangeRateOracle(m) => update_teeracle_metrics(m)?,
 		}
 		Ok(())
 	}

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -34,13 +34,13 @@ lazy_static! {
 	/// Register all the prometheus metrics we want to monitor (aside from the default process ones).
 
 	static ref ENCLAVE_ACCOUNT_FREE_BALANCE: IntGauge =
-		register_int_gauge!("enclave_account_free_balance", "Free balance of the enclave account")
+		register_int_gauge!("integritee_worker_enclave_account_free_balance", "Free balance of the enclave account")
 			.unwrap();
 	static ref ENCLAVE_SIDECHAIN_BLOCK_HEIGHT: IntGauge =
-		register_int_gauge!("enclave_sidechain_block_height", "Enclave sidechain block height")
+		register_int_gauge!("integritee_worker_enclave_sidechain_block_height", "Enclave sidechain block height")
 			.unwrap();
 	static ref ENCLAVE_SIDECHAIN_TOP_POOL_SIZE: IntGauge =
-		register_int_gauge!("enclave_sidechain_top_pool_size", "Enclave sidechain top pool size")
+		register_int_gauge!("integritee_worker_enclave_sidechain_top_pool_size", "Enclave sidechain top pool size")
 			.unwrap();
 }
 

--- a/service/src/teeracle_metrics.rs
+++ b/service/src/teeracle_metrics.rs
@@ -27,21 +27,21 @@ lazy_static! {
 	/// Register Teeracle specific metrics
 
 	static ref EXCHANGE_RATE: GaugeVec =
-		register_gauge_vec!("exchange_rate", "Exchange rates partitioned into source and trading pair", &["source", "trading_pair"])
+		register_gauge_vec!("integritee_teeracle_exchange_rate", "Exchange rates partitioned into source and trading pair", &["source", "trading_pair"])
 			.unwrap();
 	static ref RESPONSE_TIME: IntGaugeVec =
-		register_int_gauge_vec!("oracle_response_times", "Response times in ms for requests that the oracle makes", &["source"])
+		register_int_gauge_vec!("integritee_teeracle_response_times", "Response times in ms for requests that the oracle makes", &["source"])
 			.unwrap();
 	static ref NUMBER_OF_REQUESTS: IntCounterVec =
-		register_int_counter_vec!("number_of_requests", "Number of requests made per source", &["source"])
+		register_int_counter_vec!("integritee_teeracle_number_of_requests", "Number of requests made per source", &["source"])
 			.unwrap();
 
 	static ref NUMBER_OF_REQUEST_FAILURES: IntCounter =
-		register_int_counter!("oracle_request_failures", "Number of requests that failed")
+		register_int_counter!("integritee_teeracle_request_failures", "Number of requests that failed")
 			.unwrap();
 
 	static ref EXTRINSIC_INCLUSION_SUCCESS: IntGauge =
-		register_int_gauge!("oracle_extrinsic_inclusion_success", "1 if extrinsics was successfully finalized, 0 if not")
+		register_int_gauge!("integritee_teeracle_extrinsic_inclusion_success", "1 if extrinsics was successfully finalized, 0 if not")
 			.unwrap();
 }
 

--- a/service/src/teeracle_metrics.rs
+++ b/service/src/teeracle_metrics.rs
@@ -1,0 +1,76 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{error::ServiceResult, Error};
+use itp_enclave_metrics::ExchangeRateOracleMetric;
+use lazy_static::lazy_static;
+use prometheus::{
+	register_gauge_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+	register_int_gauge_vec, GaugeVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+};
+
+lazy_static! {
+	/// Register Teeracle specific metrics
+
+	static ref EXCHANGE_RATE: GaugeVec =
+		register_gauge_vec!("exchange_rate", "Exchange rates partitioned into source and trading pair", &["source", "trading_pair"])
+			.unwrap();
+	static ref RESPONSE_TIME: IntGaugeVec =
+		register_int_gauge_vec!("oracle_response_times", "Response times in ms for requests that the oracle makes", &["source"])
+			.unwrap();
+	static ref NUMBER_OF_REQUESTS: IntCounterVec =
+		register_int_counter_vec!("number_of_requests", "Number of requests made per source", &["source"])
+			.unwrap();
+
+	static ref NUMBER_OF_REQUEST_FAILURES: IntCounter =
+		register_int_counter!("oracle_request_failures", "Number of requests that failed")
+			.unwrap();
+
+	static ref EXTRINSIC_INCLUSION_SUCCESS: IntGauge =
+		register_int_gauge!("oracle_extrinsic_inclusion_success", "1 if extrinsics was successfully finalized, 0 if not")
+			.unwrap();
+}
+
+pub fn increment_number_of_request_failures() {
+	NUMBER_OF_REQUEST_FAILURES.inc();
+}
+
+pub fn set_extrinsics_inclusion_success(is_successful: bool) {
+	let success_values = if is_successful { 1 } else { 0 };
+	EXTRINSIC_INCLUSION_SUCCESS.set(success_values);
+}
+
+pub fn update_teeracle_metrics(metric: ExchangeRateOracleMetric) -> ServiceResult<()> {
+	match metric {
+		ExchangeRateOracleMetric::ExchangeRate(source, trading_pair, exchange_rate) =>
+			EXCHANGE_RATE
+				.get_metric_with_label_values(&[source.as_str(), trading_pair.as_str()])
+				.map(|m| m.set(exchange_rate.to_num()))
+				.map_err(|e| Error::Custom(e.into()))?,
+
+		ExchangeRateOracleMetric::ResponseTime(source, t) => RESPONSE_TIME
+			.get_metric_with_label_values(&[source.as_str()])
+			.map(|m| m.set(t as i64))
+			.map_err(|e| Error::Custom(e.into()))?,
+
+		ExchangeRateOracleMetric::NumberRequestsIncrement(source) => NUMBER_OF_REQUESTS
+			.get_metric_with_label_values(&[source.as_str()])
+			.map(|m| m.inc())
+			.map_err(|e| Error::Custom(e.into()))?,
+	};
+	Ok(())
+}

--- a/sidechain/top-pool-rpc-author/src/author_tests.rs
+++ b/sidechain/top-pool-rpc-author/src/author_tests.rs
@@ -108,7 +108,7 @@ fn create_author_with_filter<F: Filter<Value = TrustedOperation>>(
 	let _ = state_facade.load_initialized(&shard_id).unwrap();
 
 	let encryption_key = ShieldingCryptoMock::default();
-	let ocall_mock = Arc::new(MetricsOCallMock {});
+	let ocall_mock = Arc::new(MetricsOCallMock::default());
 
 	(
 		Author::new(


### PR DESCRIPTION
* Extend the existing Prometheus metrics exporter with Teeracle specific metrics (according to #9)
* All exported metrics are prefixed with `integritee_`
* Metrics export is disabled by default in the `integritee-service`, has to be enabled by setting the flag `--enable-metrics`

Closes #9 