### PR TITLE
Refactor exchange rate oracle, extract generic parts

### DIFF
--- a/app-libs/exchange-oracle/src/exchange_rate_oracle.rs
+++ b/app-libs/exchange-oracle/src/exchange_rate_oracle.rs
@@ -1,0 +1,118 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use crate::{metrics_exporter::ExportMetrics, Error, GetExchangeRate, TradingPair};
+use core::time::Duration;
+use itc_rest_client::{http_client::HttpClient, rest_client::RestClient};
+use itp_types::ExchangeRate;
+use std::{string::String, sync::Arc, time::Instant};
+use url::Url;
+
+/// Oracle source trait used by the `ExchangeRateOracle` (strategy pattern).
+pub trait OracleSource {
+	fn id(&self) -> String;
+
+	fn request_timeout(&self) -> Option<Duration>;
+
+	fn base_url(&self) -> Result<Url, Error>;
+
+	fn send_exchange_rate_request(
+		&self,
+		rest_client: &mut RestClient<HttpClient>,
+		trading_pair: TradingPair,
+	) -> Result<ExchangeRate, Error>;
+}
+
+pub struct ExchangeRateOracle<OracleSourceType, MetricsExporter> {
+	oracle_source: OracleSourceType,
+	metrics_exporter: Arc<MetricsExporter>,
+}
+
+impl<OracleSourceType, MetricsExporter> ExchangeRateOracle<OracleSourceType, MetricsExporter>
+where
+	OracleSourceType: OracleSource,
+	MetricsExporter: ExportMetrics,
+{
+	pub fn new(oracle_source: OracleSourceType, metrics_exporter: Arc<MetricsExporter>) -> Self {
+		ExchangeRateOracle { oracle_source, metrics_exporter }
+	}
+
+	pub fn base_url(&self) -> Result<Url, Error> {
+		self.oracle_source.base_url()
+	}
+}
+
+impl<OracleSourceType, MetricsExporter> GetExchangeRate
+	for ExchangeRateOracle<OracleSourceType, MetricsExporter>
+where
+	OracleSourceType: OracleSource,
+	MetricsExporter: ExportMetrics,
+{
+	fn get_exchange_rate(&self, trading_pair: TradingPair) -> Result<(ExchangeRate, Url), Error> {
+		let source_id = self.oracle_source.id();
+		self.metrics_exporter.increment_number_requests(source_id.clone());
+
+		let base_url = self.oracle_source.base_url()?;
+		let http_client = HttpClient::new(true, self.oracle_source.request_timeout(), None, None);
+		let mut rest_client = RestClient::new(http_client, base_url.clone());
+
+		let timer_start = Instant::now();
+
+		match self
+			.oracle_source
+			.send_exchange_rate_request(&mut rest_client, trading_pair.clone())
+		{
+			Ok(er) => {
+				self.metrics_exporter.record_response_time(source_id.clone(), timer_start);
+				self.metrics_exporter.update_exchange_rate(source_id, er, trading_pair);
+				Ok((er, base_url))
+			},
+			Err(e) => Err(e),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{MetricsExporterMock, OracleSourceMock};
+
+	type TestOracle = ExchangeRateOracle<OracleSourceMock, MetricsExporterMock>;
+
+	#[test]
+	fn get_exchange_rate_updates_metrics() {
+		let metrics_exporter = Arc::new(MetricsExporterMock::default());
+		let test_client = TestOracle::new(OracleSourceMock {}, metrics_exporter.clone());
+
+		let trading_pair =
+			TradingPair { crypto_currency: "BTC".to_string(), fiat_currency: "USD".to_string() };
+		let _bit_usd = test_client.get_exchange_rate(trading_pair.clone()).unwrap();
+
+		assert_eq!(1, metrics_exporter.get_number_request());
+		assert_eq!(1, metrics_exporter.get_response_times().len());
+		assert_eq!(1, metrics_exporter.get_exchange_rates().len());
+
+		let (metric_trading_pair, exchange_rate) =
+			metrics_exporter.get_exchange_rates().first().unwrap().clone();
+
+		assert_eq!(trading_pair, metric_trading_pair);
+		assert_eq!(ExchangeRate::from_num(42.3f32), exchange_rate);
+	}
+}

--- a/app-libs/exchange-oracle/src/metrics_exporter.rs
+++ b/app-libs/exchange-oracle/src/metrics_exporter.rs
@@ -1,0 +1,86 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::TradingPair;
+use itp_enclave_metrics::{EnclaveMetric, ExchangeRateOracleMetric};
+use itp_ocall_api::EnclaveMetricsOCallApi;
+use itp_types::ExchangeRate;
+use log::error;
+use std::{string::String, sync::Arc, time::Instant};
+
+/// Trait to export metrics for any Teeracle.
+pub trait ExportMetrics {
+	fn increment_number_requests(&self, source: String);
+
+	fn record_response_time(&self, source: String, timer: Instant);
+
+	fn update_exchange_rate(
+		&self,
+		source: String,
+		exchange_rate: ExchangeRate,
+		trading_pair: TradingPair,
+	);
+}
+
+/// Metrics exporter implementation.
+pub struct MetricsExporter<OCallApi> {
+	ocall_api: Arc<OCallApi>,
+}
+
+impl<OCallApi> MetricsExporter<OCallApi>
+where
+	OCallApi: EnclaveMetricsOCallApi,
+{
+	pub fn new(ocall_api: Arc<OCallApi>) -> Self {
+		MetricsExporter { ocall_api }
+	}
+
+	fn update_metric(&self, metric: ExchangeRateOracleMetric) {
+		if let Err(e) = self.ocall_api.update_metric(EnclaveMetric::ExchangeRateOracle(metric)) {
+			error!("Failed to update enclave metric, sgx_status_t: {}", e)
+		}
+	}
+}
+
+impl<OCallApi> ExportMetrics for MetricsExporter<OCallApi>
+where
+	OCallApi: EnclaveMetricsOCallApi,
+{
+	fn increment_number_requests(&self, source: String) {
+		self.update_metric(ExchangeRateOracleMetric::NumberRequestsIncrement(source));
+	}
+
+	fn record_response_time(&self, source: String, timer: Instant) {
+		self.update_metric(ExchangeRateOracleMetric::ResponseTime(
+			source,
+			timer.elapsed().as_millis(),
+		));
+	}
+
+	fn update_exchange_rate(
+		&self,
+		source: String,
+		exchange_rate: ExchangeRate,
+		trading_pair: TradingPair,
+	) {
+		self.update_metric(ExchangeRateOracleMetric::ExchangeRate(
+			source,
+			trading_pair.key(),
+			exchange_rate,
+		));
+	}
+}

--- a/app-libs/exchange-oracle/src/mock.rs
+++ b/app-libs/exchange-oracle/src/mock.rs
@@ -1,0 +1,99 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(feature = "sgx")]
+use std::sync::SgxRwLock as RwLock;
+
+#[cfg(feature = "std")]
+use std::sync::RwLock;
+
+use crate::{
+	error::Error, exchange_rate_oracle::OracleSource, metrics_exporter::ExportMetrics, TradingPair,
+};
+use itc_rest_client::{http_client::HttpClient, rest_client::RestClient};
+use itp_types::ExchangeRate;
+use std::{
+	time::{Duration, Instant},
+	vec::Vec,
+};
+use url::Url;
+
+/// Mock metrics exporter.
+#[derive(Default)]
+pub(crate) struct MetricsExporterMock {
+	number_requests: RwLock<u64>,
+	response_times: RwLock<Vec<u128>>,
+	exchange_rates: RwLock<Vec<(TradingPair, ExchangeRate)>>,
+}
+
+impl MetricsExporterMock {
+	pub fn get_number_request(&self) -> u64 {
+		*self.number_requests.read().unwrap()
+	}
+
+	pub fn get_response_times(&self) -> Vec<u128> {
+		self.response_times.read().unwrap().clone()
+	}
+
+	pub fn get_exchange_rates(&self) -> Vec<(TradingPair, ExchangeRate)> {
+		self.exchange_rates.read().unwrap().clone()
+	}
+}
+
+impl ExportMetrics for MetricsExporterMock {
+	fn increment_number_requests(&self, _source: String) {
+		(*self.number_requests.write().unwrap()) += 1;
+	}
+
+	fn record_response_time(&self, _source: String, timer: Instant) {
+		self.response_times.write().unwrap().push(timer.elapsed().as_millis());
+	}
+
+	fn update_exchange_rate(
+		&self,
+		_source: String,
+		exchange_rate: ExchangeRate,
+		trading_pair: TradingPair,
+	) {
+		self.exchange_rates.write().unwrap().push((trading_pair, exchange_rate));
+	}
+}
+
+/// Mock oracle source.
+pub(crate) struct OracleSourceMock;
+
+impl OracleSource for OracleSourceMock {
+	fn id(&self) -> String {
+		"source_mock".to_string()
+	}
+
+	fn request_timeout(&self) -> Option<Duration> {
+		None
+	}
+
+	fn base_url(&self) -> Result<Url, Error> {
+		Url::parse("https://mock.base.url").map_err(|e| Error::Other(format!("{:?}", e).into()))
+	}
+
+	fn send_exchange_rate_request(
+		&self,
+		_rest_client: &mut RestClient<HttpClient>,
+		_trading_pair: TradingPair,
+	) -> Result<ExchangeRate, Error> {
+		Ok(ExchangeRate::from_num(42.3f32))
+	}
+}

--- a/app-libs/exchange-oracle/src/types.rs
+++ b/app-libs/exchange-oracle/src/types.rs
@@ -15,15 +15,11 @@
 
 */
 
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-extern crate sgx_tstd as std;
-
-use crate::error::Error;
 use codec::{Decode, Encode};
 use std::string::String;
 
 /// Market identifier for order
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode, Eq, PartialEq)]
 pub struct TradingPair {
 	pub crypto_currency: String,
 	pub fiat_currency: String,
@@ -32,15 +28,5 @@ pub struct TradingPair {
 impl TradingPair {
 	pub fn key(self) -> String {
 		format!("{}/{}", self.crypto_currency, self.fiat_currency)
-	}
-}
-
-pub trait TradingPairId {
-	fn crypto_currency_id(&mut self, trading_pair: TradingPair) -> Result<String, Error> {
-		Ok(trading_pair.crypto_currency)
-	}
-
-	fn fiat_currency_id(&mut self, trading_pair: TradingPair) -> Result<String, Error> {
-		Ok(trading_pair.fiat_currency)
 	}
 }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -84,6 +84,7 @@ cid = { git = "https://github.com/whalelephant/rust-cid", branch = "nstd", defau
 multibase = { git = "https://github.com/whalelephant/rust-multibase", branch = "nstd", default-features = false }
 
 # local deps
+ita-exchange-oracle = { path = "../app-libs/exchange-oracle", default-features = false, features = ["sgx"] }
 ita-stf = { path = "../app-libs/stf", default-features = false, features = ["sgx"] }
 itc-tls-websocket-server = { path = "../core/tls-websocket-server", default-features = false, features = ["sgx"] }
 itc-direct-rpc-server = { path = "../core/direct-rpc-server", default-features = false, features = ["sgx"]  }
@@ -106,7 +107,6 @@ itp-teerex-storage = { path = "../core-primitives/teerex-storage", default-featu
 itp-test = { path = "../core-primitives/test", default-features = false, optional = true }
 itp-types = { path = "../core-primitives/types", default-features = false, features = ["sgx"] }
 its-sidechain = { path = "../sidechain/sidechain-crate", default-features = false, features = ["sgx"] }
-ita-exchange-oracle = { path = "../app-libs/exchange-oracle", default-features = false, features = ["sgx"] }
 
 # substrate deps
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }


### PR DESCRIPTION
Preparation for #4. Extract generic parts from the oracle (including metrics) and isolate CoinGecko specific parts.

* Uses the strategy pattern to inject the source specific (e.g. CoinGecko) behavior into an abstract exchange rate oracle.


![teeracle-abstraction-refactoring drawio](https://user-images.githubusercontent.com/9334190/159481144-a07807c4-aea2-487a-b97c-41a09c1ad01c.png)

