### PR TITLE
Oracle implementation for the CoinMarketCap source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,7 @@ dependencies = [
  "serde 1.0.136",
  "serde_json 1.0.79",
  "sgx_tstd",
+ "substrate-fixed",
  "thiserror 1.0.30",
  "thiserror 1.0.9",
  "url 2.1.1",

--- a/app-libs/exchange-oracle/Cargo.toml
+++ b/app-libs/exchange-oracle/Cargo.toml
@@ -52,3 +52,4 @@ itp-types = { path = "../../core-primitives/types", default-features = false }
 
 [dev-dependencies]
 itp-test = { path = "../../core-primitives/test" }
+substrate-fixed = { package = "substrate-fixed", git = "https://github.com/encointer/substrate-fixed", tag = "v0.5.9"}

--- a/app-libs/exchange-oracle/src/coin_gecko.rs
+++ b/app-libs/exchange-oracle/src/coin_gecko.rs
@@ -63,7 +63,7 @@ impl CoinGeckoSource {
 }
 
 impl OracleSource for CoinGeckoSource {
-	fn id(&self) -> String {
+	fn metrics_id(&self) -> String {
 		"coin_gecko".to_string()
 	}
 
@@ -75,7 +75,7 @@ impl OracleSource for CoinGeckoSource {
 		Url::parse(COINGECKO_URL).map_err(|e| Error::Other(format!("{:?}", e).into()))
 	}
 
-	fn send_exchange_rate_request(
+	fn execute_exchange_rate_request(
 		&self,
 		rest_client: &mut RestClient<HttpClient>,
 		trading_pair: TradingPair,

--- a/app-libs/exchange-oracle/src/coin_market_cap.rs
+++ b/app-libs/exchange-oracle/src/coin_market_cap.rs
@@ -78,7 +78,7 @@ impl CoinMarketCapSource {
 }
 
 impl OracleSource for CoinMarketCapSource {
-	fn id(&self) -> String {
+	fn metrics_id(&self) -> String {
 		"coin_market_cap".to_string()
 	}
 
@@ -90,7 +90,7 @@ impl OracleSource for CoinMarketCapSource {
 		Url::parse(COINMARKETCAP_URL).map_err(|e| Error::Other(format!("{:?}", e).into()))
 	}
 
-	fn send_exchange_rate_request(
+	fn execute_exchange_rate_request(
 		&self,
 		rest_client: &mut RestClient<HttpClient>,
 		trading_pair: TradingPair,

--- a/app-libs/exchange-oracle/src/coin_market_cap.rs
+++ b/app-libs/exchange-oracle/src/coin_market_cap.rs
@@ -1,0 +1,230 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use crate::{error::Error, exchange_rate_oracle::OracleSource, types::TradingPair, ExchangeRate};
+use itc_rest_client::{http_client::HttpClient, rest_client::RestClient, RestGet, RestPath};
+use lazy_static::lazy_static;
+use log::*;
+use serde::{Deserialize, Serialize};
+use std::{
+	collections::{BTreeMap, HashMap},
+	string::{String, ToString},
+	time::Duration,
+};
+use url::Url;
+
+const COINMARKETCAP_URL: &str = "https://pro-api.coinmarketcap.com";
+const COINMARKETCAP_KEY: &str = "67db2bd8-ac38-4609-84fe-de9af99d9720"; //Has to be changed regenerate.
+const COINMARKETCAP_KEY_PARAM: &str = "CMC_PRO_API_KEY"; //Has to be changed regenerate.
+const FIAT_CURRENCY_PARAM: &str = "convert_id";
+const CRYPTO_CURRENCY_PARAM: &str = "id";
+const COINMARKETCAP_PATH: &str = "v2/cryptocurrency/quotes/latest";
+//const COINMARKETCAP_PATH: &str = "v1/tools/price-conversion";
+const COINMARKETCAP_TIMEOUT: Duration = Duration::from_secs(3u64);
+
+//From https://pro-api.coinmarketcap.com/v1/cryptocurrency/map?CMC_PRO_API_KEY=COINMARKETCAP_KEY
+lazy_static! {
+	static ref CRYPTO_SYMBOL_ID_MAP: HashMap<&'static str, &'static str> = HashMap::from([
+		("DOT", "6636"),//id":6636,"name":"Polkadot","symbol":"DOT"
+		("TEER", "13323"), //"id":13323,"name":"Integritee Network","symbol":"TEER"
+		("KSM", "5034"), //"id":5034,"name":"Kusama","symbol":"KSM"
+		("BTC", "1"), //"id":1,"name":"Bitcoin","symbol":"BTC"
+	]);
+}
+
+//From https://pro-api.coinmarketcap.com/v1/fiat/map?CMC_PRO_API_KEY=COINMARKETCAP_KEY
+lazy_static! {
+	static ref FIAT_SYMBOL_ID_MAP: HashMap<&'static str, &'static str> =
+		HashMap::from([("USD", "2781"), ("EUR", "2790"), ("CHF", "2785"), ("JPY", "2797"),]);
+}
+//FOR free plan:
+//https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?id=13323&convert_id=2781&CMC_PRO_API_KEY=67db2bd8-ac38-4609-84fe-de9af99d9720
+//id=13323, 5034, .... but only 1 convert options
+//{"status":{"timestamp":"2022-01-13T17:43:34.270Z","error_code":0,"error_message":null,"elapsed":30,"credit_count":1,"notice":null},"data":{"13323":{"id":13323,"name":"Integritee Network","symbol":"TEER","slug":"integritee-network","num_market_pairs":1,"date_added":"2021-10-26T15:04:11.000Z","tags":[],"max_supply":10000000,"circulating_supply":0,"total_supply":10000000,"is_active":1,"platform":null,"cmc_rank":4900,"is_fiat":0,"last_updated":"2022-01-13T17:42:00.000Z","quote":{"2781":{"price":4.967298630193371,"volume_24h":72743.61342986,"volume_change_24h":182.2754,"percent_change_1h":-1.00275087,"percent_change_24h":24.14973926,"percent_change_7d":54.10997674,"percent_change_30d":47.44551742,"percent_change_60d":2.02125024,"percent_change_90d":2.02125024,"market_cap":0,"market_cap_dominance":0,"fully_diluted_market_cap":49672986.3,"last_updated":"2022-01-13T17:42:00.000Z"}}}}}
+
+#[derive(Default)]
+pub struct CoinMarketCapSource;
+
+impl CoinMarketCapSource {
+	fn map_crypto_currency_id(trading_pair: &TradingPair) -> Result<String, Error> {
+		CRYPTO_SYMBOL_ID_MAP
+			.get(trading_pair.crypto_currency.as_str())
+			.map(|v| v.to_string())
+			.ok_or(Error::InvalidCryptoCurrencyId)
+	}
+
+	fn map_fiat_currency_id(trading_pair: &TradingPair) -> Result<String, Error> {
+		FIAT_SYMBOL_ID_MAP
+			.get(trading_pair.fiat_currency.as_str())
+			.map(|v| v.to_string())
+			.ok_or(Error::InvalidFiatCurrencyId)
+	}
+}
+
+impl OracleSource for CoinMarketCapSource {
+	fn id(&self) -> String {
+		"coin_market_cap".to_string()
+	}
+
+	fn request_timeout(&self) -> Option<Duration> {
+		Some(COINMARKETCAP_TIMEOUT)
+	}
+
+	fn base_url(&self) -> Result<Url, Error> {
+		Url::parse(COINMARKETCAP_URL).map_err(|e| Error::Other(format!("{:?}", e).into()))
+	}
+
+	fn send_exchange_rate_request(
+		&self,
+		rest_client: &mut RestClient<HttpClient>,
+		trading_pair: TradingPair,
+	) -> Result<ExchangeRate, Error> {
+		let fiat_id = Self::map_fiat_currency_id(&trading_pair)?;
+		let crypto_id = Self::map_crypto_currency_id(&trading_pair)?;
+
+		let response = rest_client
+			.get_with::<String, CoinMarketCapMarket>(
+				COINMARKETCAP_PATH.to_string(),
+				&[
+					(FIAT_CURRENCY_PARAM, &fiat_id),
+					(CRYPTO_CURRENCY_PARAM, &crypto_id),
+					(COINMARKETCAP_KEY_PARAM, COINMARKETCAP_KEY),
+				],
+			)
+			.map_err(Error::RestClient)?;
+
+		let data_struct = response.0;
+
+		println!("Got data struct {:?}", data_struct);
+
+		let data = match data_struct.data.get(&crypto_id) {
+			Some(d) => d,
+			None => {
+				error!("Got no market data from CoinMarketCap for {} ", crypto_id);
+				return Err(Error::NoValidData)
+			},
+		};
+
+		let quote = match data.quote.get(&fiat_id) {
+			Some(q) => q,
+			None => {
+				error!("Got no market data from CoinMarketCap. Check params {:?} ", trading_pair);
+				return Err(Error::NoValidData)
+			},
+		};
+		match quote.price {
+			Some(r) => Ok(ExchangeRate::from_num(r)),
+			None => {
+				error!("Failed to get the exchange rate {}", TradingPair::key(trading_pair));
+				Err(Error::EmptyExchangeRate)
+			},
+		}
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct DataStruct {
+	id: Option<u32>,
+	name: String,
+	symbol: String,
+	quote: BTreeMap<String, QuoteStruct>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct QuoteStruct {
+	price: Option<f32>,
+	last_updated: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct CoinMarketCapMarketStruct {
+	data: BTreeMap<String, DataStruct>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct CoinMarketCapMarket(pub CoinMarketCapMarketStruct);
+
+impl RestPath<String> for CoinMarketCapMarket {
+	fn get_path(path: String) -> Result<String, itc_rest_client::error::Error> {
+		Ok(path)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		exchange_rate_oracle::ExchangeRateOracle, mock::MetricsExporterMock, GetExchangeRate,
+	};
+	use core::assert_matches::assert_matches;
+	use std::sync::Arc;
+
+	type TestClient = ExchangeRateOracle<CoinMarketCapSource, MetricsExporterMock>;
+
+	fn get_coin_market_cap_crypto_currency_id(crypto_currency: &str) -> Result<String, Error> {
+		let trading_pair = TradingPair {
+			crypto_currency: crypto_currency.to_string(),
+			fiat_currency: "USD".to_string(),
+		};
+		CoinMarketCapSource::map_crypto_currency_id(&trading_pair)
+	}
+
+	#[test]
+	fn crypto_currency_id_works_for_dot() {
+		let coin_id = get_coin_market_cap_crypto_currency_id("DOT").unwrap();
+		assert_eq!(&coin_id, "6636");
+	}
+
+	#[test]
+	fn crypto_currency_id_works_for_teer() {
+		let coin_id = get_coin_market_cap_crypto_currency_id("TEER").unwrap();
+		assert_eq!(&coin_id, "13323");
+	}
+
+	#[test]
+	fn crypto_currency_id_works_for_ksm() {
+		let coin_id = get_coin_market_cap_crypto_currency_id("KSM").unwrap();
+		assert_eq!(&coin_id, "5034");
+	}
+
+	#[test]
+	fn crypto_currency_id_works_for_btc() {
+		let coin_id = get_coin_market_cap_crypto_currency_id("BTC").unwrap();
+		assert_eq!(&coin_id, "1");
+	}
+
+	#[test]
+	fn crypto_currency_id_fails_for_undefined_crypto_currency() {
+		let coin_id = get_coin_market_cap_crypto_currency_id("Undefined");
+		assert_matches!(coin_id, Err(Error::InvalidCryptoCurrencyId));
+	}
+
+	#[test]
+	fn get_exchange_rate_for_undefined_fiat_currency_fails() {
+		let coin_market_cap_client = create_client();
+		let trading_pair =
+			TradingPair { crypto_currency: "DOT".to_string(), fiat_currency: "CH".to_string() };
+		let result = coin_market_cap_client.get_exchange_rate(trading_pair);
+		assert_matches!(result, Err(Error::InvalidFiatCurrencyId));
+	}
+
+	fn create_client() -> TestClient {
+		TestClient::new(CoinMarketCapSource {}, Arc::new(MetricsExporterMock::default()))
+	}
+}

--- a/app-libs/exchange-oracle/src/error.rs
+++ b/app-libs/exchange-oracle/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
 	EmptyExchangeRate,
 	#[error("Invalid id for crypto currency")]
 	InvalidCryptoCurrencyId,
+	#[error("Invalid id for fiat currency")]
+	InvalidFiatCurrencyId,
 	#[error("Other error")]
 	Other(Box<dyn std::error::Error>),
 }

--- a/app-libs/exchange-oracle/src/exchange_rate_oracle.rs
+++ b/app-libs/exchange-oracle/src/exchange_rate_oracle.rs
@@ -27,13 +27,13 @@ use url::Url;
 
 /// Oracle source trait used by the `ExchangeRateOracle` (strategy pattern).
 pub trait OracleSource: Default {
-	fn id(&self) -> String;
+	fn metrics_id(&self) -> String;
 
 	fn request_timeout(&self) -> Option<Duration>;
 
 	fn base_url(&self) -> Result<Url, Error>;
 
-	fn send_exchange_rate_request(
+	fn execute_exchange_rate_request(
 		&self,
 		rest_client: &mut RestClient<HttpClient>,
 		trading_pair: TradingPair,
@@ -53,10 +53,6 @@ where
 	pub fn new(oracle_source: OracleSourceType, metrics_exporter: Arc<MetricsExporter>) -> Self {
 		ExchangeRateOracle { oracle_source, metrics_exporter }
 	}
-
-	pub fn base_url(&self) -> Result<Url, Error> {
-		self.oracle_source.base_url()
-	}
 }
 
 impl<OracleSourceType, MetricsExporter> GetExchangeRate
@@ -66,7 +62,7 @@ where
 	MetricsExporter: ExportMetrics,
 {
 	fn get_exchange_rate(&self, trading_pair: TradingPair) -> Result<(ExchangeRate, Url), Error> {
-		let source_id = self.oracle_source.id();
+		let source_id = self.oracle_source.metrics_id();
 		self.metrics_exporter.increment_number_requests(source_id.clone());
 
 		let base_url = self.oracle_source.base_url()?;
@@ -77,12 +73,13 @@ where
 
 		match self
 			.oracle_source
-			.send_exchange_rate_request(&mut rest_client, trading_pair.clone())
+			.execute_exchange_rate_request(&mut rest_client, trading_pair.clone())
 		{
-			Ok(er) => {
+			Ok(exchange_rate) => {
 				self.metrics_exporter.record_response_time(source_id.clone(), timer_start);
-				self.metrics_exporter.update_exchange_rate(source_id, er, trading_pair);
-				Ok((er, base_url))
+				self.metrics_exporter
+					.update_exchange_rate(source_id, exchange_rate, trading_pair);
+				Ok((exchange_rate, base_url))
 			},
 			Err(e) => Err(e),
 		}

--- a/app-libs/exchange-oracle/src/exchange_rate_oracle.rs
+++ b/app-libs/exchange-oracle/src/exchange_rate_oracle.rs
@@ -26,7 +26,7 @@ use std::{string::String, sync::Arc, time::Instant};
 use url::Url;
 
 /// Oracle source trait used by the `ExchangeRateOracle` (strategy pattern).
-pub trait OracleSource {
+pub trait OracleSource: Default {
 	fn id(&self) -> String;
 
 	fn request_timeout(&self) -> Option<Duration>;

--- a/app-libs/exchange-oracle/src/lib.rs
+++ b/app-libs/exchange-oracle/src/lib.rs
@@ -36,15 +36,17 @@ pub mod sgx_reexport_prelude {
 use crate::sgx_reexport_prelude::*;
 
 use crate::{
-	coingecko::CoinGeckoSource, error::Error, exchange_rate_oracle::ExchangeRateOracle,
-	metrics_exporter::MetricsExporter, types::TradingPair,
+	coin_gecko::CoinGeckoSource, coin_market_cap::CoinMarketCapSource, error::Error,
+	exchange_rate_oracle::ExchangeRateOracle, metrics_exporter::MetricsExporter,
+	types::TradingPair,
 };
 use itp_ocall_api::EnclaveMetricsOCallApi;
 use itp_types::ExchangeRate;
 use std::sync::Arc;
 use url::Url;
 
-pub mod coingecko;
+pub mod coin_gecko;
+pub mod coin_market_cap;
 pub mod error;
 pub mod exchange_rate_oracle;
 pub mod metrics_exporter;
@@ -53,13 +55,25 @@ pub mod types;
 #[cfg(test)]
 mod mock;
 
+#[cfg(test)]
+mod test;
+
 pub type CoinGeckoExchangeRateOracle<OCallApi> =
 	ExchangeRateOracle<CoinGeckoSource, MetricsExporter<OCallApi>>;
 
-pub fn create_coingecko_oracle<OCallApi: EnclaveMetricsOCallApi>(
+pub type CoinMarketCapExchangeRateOracle<OCallApi> =
+	ExchangeRateOracle<CoinMarketCapSource, MetricsExporter<OCallApi>>;
+
+pub fn create_coin_gecko_oracle<OCallApi: EnclaveMetricsOCallApi>(
 	ocall_api: Arc<OCallApi>,
 ) -> CoinGeckoExchangeRateOracle<OCallApi> {
 	ExchangeRateOracle::new(CoinGeckoSource {}, Arc::new(MetricsExporter::new(ocall_api)))
+}
+
+pub fn create_coin_market_cap_oracle<OCallApi: EnclaveMetricsOCallApi>(
+	ocall_api: Arc<OCallApi>,
+) -> CoinMarketCapExchangeRateOracle<OCallApi> {
+	ExchangeRateOracle::new(CoinMarketCapSource {}, Arc::new(MetricsExporter::new(ocall_api)))
 }
 
 pub trait GetExchangeRate {

--- a/app-libs/exchange-oracle/src/mock.rs
+++ b/app-libs/exchange-oracle/src/mock.rs
@@ -74,6 +74,7 @@ impl ExportMetrics for MetricsExporterMock {
 }
 
 /// Mock oracle source.
+#[derive(Default)]
 pub(crate) struct OracleSourceMock;
 
 impl OracleSource for OracleSourceMock {

--- a/app-libs/exchange-oracle/src/mock.rs
+++ b/app-libs/exchange-oracle/src/mock.rs
@@ -78,7 +78,7 @@ impl ExportMetrics for MetricsExporterMock {
 pub(crate) struct OracleSourceMock;
 
 impl OracleSource for OracleSourceMock {
-	fn id(&self) -> String {
+	fn metrics_id(&self) -> String {
 		"source_mock".to_string()
 	}
 
@@ -90,7 +90,7 @@ impl OracleSource for OracleSourceMock {
 		Url::parse("https://mock.base.url").map_err(|e| Error::Other(format!("{:?}", e).into()))
 	}
 
-	fn send_exchange_rate_request(
+	fn execute_exchange_rate_request(
 		&self,
 		_rest_client: &mut RestClient<HttpClient>,
 		_trading_pair: TradingPair,

--- a/app-libs/exchange-oracle/src/test.rs
+++ b/app-libs/exchange-oracle/src/test.rs
@@ -1,0 +1,93 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Integration tests for concrete exchange rate oracle implementations.
+//! Uses real HTTP requests, so the sites must be available for these tests.
+
+use crate::{
+	coin_gecko::CoinGeckoSource,
+	coin_market_cap::CoinMarketCapSource,
+	error::Error,
+	exchange_rate_oracle::{ExchangeRateOracle, OracleSource},
+	mock::MetricsExporterMock,
+	GetExchangeRate, TradingPair,
+};
+use core::assert_matches::assert_matches;
+use std::sync::Arc;
+use substrate_fixed::transcendental::ZERO;
+
+type TestOracle<OracleSource> = ExchangeRateOracle<OracleSource, MetricsExporterMock>;
+
+#[test]
+fn get_exchange_rate_from_coin_market_cap_works() {
+	test_suite_exchange_rates::<CoinMarketCapSource>();
+}
+
+#[test]
+fn get_exchange_rate_from_coin_gecko_works() {
+	test_suite_exchange_rates::<CoinGeckoSource>();
+}
+
+#[test]
+fn get_exchange_rate_for_undefined_coin_market_cap_crypto_currency_fails() {
+	get_exchange_rate_for_undefined_crypto_currency_fails::<CoinMarketCapSource>();
+}
+
+#[test]
+fn get_exchange_rate_for_undefined_coin_gecko_crypto_currency_fails() {
+	get_exchange_rate_for_undefined_crypto_currency_fails::<CoinGeckoSource>();
+}
+
+fn create_exchange_rate_oracle<OracleSourceType: OracleSource>() -> TestOracle<OracleSourceType> {
+	let oracle_source = OracleSourceType::default();
+	ExchangeRateOracle::new(oracle_source, Arc::new(MetricsExporterMock::default()))
+}
+
+fn get_exchange_rate_for_undefined_crypto_currency_fails<OracleSourceType: OracleSource>() {
+	let oracle = create_exchange_rate_oracle::<OracleSourceType>();
+	let trading_pair = TradingPair {
+		crypto_currency: "invalid_coin".to_string(),
+		fiat_currency: "USD".to_string(),
+	};
+	let result = oracle.get_exchange_rate(trading_pair);
+	assert_matches!(result, Err(Error::InvalidCryptoCurrencyId));
+}
+
+fn test_suite_exchange_rates<OracleSourceType: OracleSource>() {
+	let oracle = create_exchange_rate_oracle::<OracleSourceType>();
+
+	let dot_to_usd =
+		TradingPair { crypto_currency: "DOT".to_string(), fiat_currency: "USD".to_string() };
+	let dot_usd = oracle.get_exchange_rate(dot_to_usd).unwrap().0;
+	assert!(dot_usd > 0f32);
+	let btc_to_usd =
+		TradingPair { crypto_currency: "BTC".to_string(), fiat_currency: "USD".to_string() };
+	let bit_usd = oracle.get_exchange_rate(btc_to_usd).unwrap().0;
+	assert!(bit_usd > 0f32);
+	let dot_to_chf =
+		TradingPair { crypto_currency: "DOT".to_string(), fiat_currency: "CHF".to_string() };
+	let dot_chf = oracle.get_exchange_rate(dot_to_chf).unwrap().0;
+	assert!(dot_chf > 0f32);
+	let bit_to_chf =
+		TradingPair { crypto_currency: "BTC".to_string(), fiat_currency: "CHF".to_string() };
+	let bit_chf = oracle.get_exchange_rate(bit_to_chf).unwrap().0;
+
+	//Ensure that get_exchange_rate return a positive rate
+	assert!(dot_usd > ZERO);
+	//Ensure that the exchange rates' values make sense
+	assert_eq!((dot_usd / bit_usd).round(), (dot_chf / bit_chf).round());
+}

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -692,7 +692,7 @@ fn update_market_data_internal(
 	let trading_pair = TradingPair { crypto_currency, fiat_currency };
 	let coin_gecko_client = create_coin_gecko_oracle(Arc::new(OcallApi));
 	let (rate, base_url) = match coin_gecko_client.get_exchange_rate(trading_pair.clone()) {
-		Ok(r) => r,
+		Ok(result) => result,
 		Err(e) => {
 			error!("[-] Failed to get the newest exchange rate from CoinGecko. {:?}", e);
 			return Err(Error::Other(e.into()))

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -49,7 +49,7 @@ use crate::{
 };
 use base58::ToBase58;
 use codec::{alloc::string::String, Decode, Encode};
-use ita_exchange_oracle::{create_coingecko_oracle, types::TradingPair, GetExchangeRate};
+use ita_exchange_oracle::{create_coin_gecko_oracle, types::TradingPair, GetExchangeRate};
 use ita_stf::{Getter, ShardIdentifier, Stf};
 use itc_direct_rpc_server::{
 	create_determine_watch, rpc_connection_registry::ConnectionRegistry,
@@ -690,11 +690,11 @@ fn update_market_data_internal(
 
 	// Get the exchange rate
 	let trading_pair = TradingPair { crypto_currency, fiat_currency };
-	let coingecko_client = create_coingecko_oracle(Arc::new(OcallApi));
-	let (rate, base_url) = match coingecko_client.get_exchange_rate(trading_pair.clone()) {
+	let coin_gecko_client = create_coin_gecko_oracle(Arc::new(OcallApi));
+	let (rate, base_url) = match coin_gecko_client.get_exchange_rate(trading_pair.clone()) {
 		Ok(r) => r,
 		Err(e) => {
-			error!("[-] Failed to get the newest exchange rate from coingecko. {:?}", e);
+			error!("[-] Failed to get the newest exchange rate from CoinGecko. {:?}", e);
 			return Err(Error::Other(e.into()))
 		},
 	};


### PR DESCRIPTION
As described in #4, implement CoinMarketCap as source. This branch/PR is based on @echevrier 's PR #13, but merged with the new refactoring and abstraction of the oracle logic

- [x] Merge PR #23 first

Closes #4 